### PR TITLE
Don't specify settings binding explicitly.

### DIFF
--- a/octoprint_display_eta/static/js/display_eta.js
+++ b/octoprint_display_eta/static/js/display_eta.js
@@ -27,7 +27,7 @@ $(function() {
     OCTOPRINT_VIEWMODELS.push({
         construct: ETAModel,
         dependencies: ["printerStateViewModel", "settingsViewModel"],
-        elements: ["#navbar_plugin_octoprint_display_eta","#ETA_string","#settings_plugin_display_eta"]
+        elements: ["#navbar_plugin_octoprint_display_eta","#ETA_string"]
     });
 });
 


### PR DESCRIPTION
It's not needed if the settings page uses the standard naming convention.

Specifying the binding explicitly results in a duplicate binding error in the JavaScript console.