### PR TITLE
Option to show ETA only when printing

### DIFF
--- a/octoprint_display_eta/__init__.py
+++ b/octoprint_display_eta/__init__.py
@@ -34,6 +34,9 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
         # Check if the user has chosen to display the ETA on the printer LCD
         self.doM117 = self._settings.get(['displayOnPrinter'])
 
+        # Check if the user wants M117 only whilst printing
+        self.doM117OnlyWhilstPrinting = self._settings.get(['m117OnlyWhilstPrinting'])
+
         # Check if the user has chosen to use 24hr time
         if self._settings.get(['time24hr']) is True:
             # See http://babel.pocoo.org/en/latest/dates.html#time-fields
@@ -85,6 +88,9 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
         else:
             self.doM117 = False
             self.logger.debug('M117 = False')
+
+        self.doM117OnlyWhilstPrinting = self._settings.get(['m117OnlyWhilstPrinting'])
+        self.logger.debug('M117 only whilst printing: {}'.format(self.doM117OnlyWhilstPrinting))
 
         # Check if the user has chosen to remove colons from the ETA displayed on the printer LCD
         if self._settings.get(["removeColons"]) is True:
@@ -270,7 +276,7 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
         # Check if the user has chosen to display the ETA on the printer LCD
         if self.doM117 is True:
             # Check if the user has chosen to remove colons from the output to the printer LCD
-            if self.replaceColons is True:
+            if self.doM117 is True and (self._printer.is_printing() or not self.doM117OnlyWhilstPrinting):
                 # Send the ETA to the printer LCD, minus the colons
                 self._printer.commands("M117 ETA is {}".format(self.eta_string.replace(":", " ")))
             else:

--- a/octoprint_display_eta/__init__.py
+++ b/octoprint_display_eta/__init__.py
@@ -274,9 +274,9 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
         # Send the current ETA to the Web UI
         self._plugin_manager.send_plugin_message(self._identifier, dict(eta_string=self.eta_string))
         # Check if the user has chosen to display the ETA on the printer LCD
-        if self.doM117 is True:
+        if self.doM117 is True and (self._printer.is_printing() or not self.doM117OnlyWhilstPrinting):
             # Check if the user has chosen to remove colons from the output to the printer LCD
-            if self.doM117 is True and (self._printer.is_printing() or not self.doM117OnlyWhilstPrinting):
+            if self.replaceColons is True:
                 # Send the ETA to the printer LCD, minus the colons
                 self._printer.commands("M117 ETA is {}".format(self.eta_string.replace(":", " ")))
             else:

--- a/octoprint_display_eta/templates/display_eta_settings.jinja2
+++ b/octoprint_display_eta/templates/display_eta_settings.jinja2
@@ -8,6 +8,9 @@
             <input type="checkbox" data-bind="checked: settings.plugins.display_eta.displayOnPrinter">{{ _('Display the ETA on your printers LCD screen') }}
             </label>
 			<label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.display_eta.m117OnlyWhilstPrinting">{{ _('Only display ETA on the LCD when the printer is printing') }}
+            </label>
+			<label class="checkbox">
             <input type="checkbox" data-bind="checked: settings.plugins.display_eta.removeColons">{{ _('Remove all colons(:) from the time that is displayed on the printer (required for certain printer firmwares)') }}
             </label>
         </div>


### PR DESCRIPTION
A simple, user configurable addition to only show ETA on printers LCD when its printing.