### PR TITLE
Add Custom Time Format String setting - courtesy of @LMBernardo (#39)

### DIFF
--- a/octoprint_display_eta/__init__.py
+++ b/octoprint_display_eta/__init__.py
@@ -1,11 +1,11 @@
 # coding=utf-8
-from __future__ import absolute_import
-
 import octoprint.plugin
 from octoprint.util import RepeatedTimer
-import datetime
+
+from datetime import datetime, timedelta
 import logging
-from babel.dates import format_date, format_time
+from babel import default_locale, localedata
+from babel.dates import format_datetime
 import flask
 
 
@@ -34,13 +34,16 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
         # Check if the user has chosen to display the ETA on the printer LCD
         self.doM117 = self._settings.get(['displayOnPrinter'])
 
-        # Check if the user has chosen to use 24hr time
-        if self._settings.get(['time24hr']) is True:
+        # Check for custom time string
+        if (self._settings.get(["customTimeStringEnable"]) is True) and (len(self._settings.get(["customTimeString"])) > 0):
+            self.CustomTimeFormat = self._settings.get(["customTimeString"])
+        # Else check if the user has chosen to use 24hr time
+        elif self._settings.get(['time24hr']) is True:
             # See http://babel.pocoo.org/en/latest/dates.html#time-fields
-            self.CustomTimeFormat = "HH:mm:ss"
+            self.CustomTimeFormat = "'ETA is 'HH:mm:ss"
         else:
             # See http://babel.pocoo.org/en/latest/dates.html#time-fields
-            self.CustomTimeFormat = "hh:mm:ss a"
+            self.CustomTimeFormat = "'ETA is 'hh:mm:ss a"
 
         # Check if the user has chosen to remove colons from the ETA displayed on the printer LCD
         self.replaceColons = self._settings.get(['removeColons'])
@@ -59,7 +62,10 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
             time24hr=False,
             displayOnPrinter=True,
             removeColons=False,
-            updateInterval=10.0
+            updateInterval=10.0,
+            customTimeStringEnable=False,
+            customTimeString="'ETA is 'hh:mm:ss a",
+            locale=default_locale('LC_TIME') if len(default_locale('LC_TIME')) > 0 and (default_locale('LC_TIME') in localedata.locale_identifiers()) else "en_US"
         )
 
     # Function to run when the settings are saved
@@ -67,16 +73,19 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
         # Store the new settings values for easy access
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
 
-        # Check if the user has chosen to use 24hr time
-        if self._settings.get(["time24hr"]) is True:
+        # Check if the user has chosen a custom time string
+        if (self._settings.get(["customTimeStringEnable"]) is True) and (len(self._settings.get(["customTimeString"])) > 0):
+            self.logger.debug('CTS = True')
+            self.CustomTimeFormat = self._settings.get(["customTimeString"])
+        # Else check if the user has chosen to use 24hr time
+        elif self._settings.get(["time24hr"]) is True:
             self.logger.debug('24HR = True')
             # See http://babel.pocoo.org/en/latest/dates.html#time-fields for details on the time format
-            self.CustomTimeFormat = "HH:mm:ss"
-            pass
+            self.CustomTimeFormat = "'ETA is 'HH:mm:ss"
         else:
             self.logger.debug('24HR = False')
             # See http://babel.pocoo.org/en/latest/dates.html#time-fields for details on the time format
-            self.CustomTimeFormat = "hh:mm:ss a"
+            self.CustomTimeFormat = "'ETA is 'hh:mm:ss a"
 
         # Check if the user has chosen to display the ETA on the printer LCD
         if self._settings.get(["displayOnPrinter"]) is True:
@@ -141,7 +150,7 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
             # Start the timer
             self.timer.start()
             self.logger.debug('reached end of on_event')
-        # If the even starts with Print but isn't PrintStarted or PrintResumed
+        # If the event starts with Print but isn't PrintStarted or PrintResumed
         elif event == octoprint.events.Events.PRINT_PAUSED or event == octoprint.events.Events.PRINT_CANCELLED or event == octoprint.events.Events.PRINT_FAILED or event == octoprint.events.Events.PRINT_DONE:
             self.logger.debug('not printing event received')
             # Stop the timer
@@ -236,11 +245,11 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
             return "-"
 
         # Get the current time and date
-        current_time = datetime.datetime.today()
+        current_time = datetime.today()
         # Add the time left for the current print to the current time and date
-        finish_time = current_time + datetime.timedelta(0, time_left)
-        # Format the time according to the users choice (either 12hr or 24hr time)
-        strtime = format_time(finish_time, self.CustomTimeFormat)
+        finish_time = current_time + timedelta(0, time_left)
+        # Format the time according to the users choice (either 12hr / 24hr time or custom time string)
+        strtime = format_datetime(finish_time, format = self.CustomTimeFormat, locale = self._settings.get(['locale']))
         self.logger.debug('strtime = ' + strtime)
         # Create an empty string to store the finish date for the print
         strdate = ""
@@ -253,7 +262,7 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
             # If the print will finish after tomorrow
             else:
                 # Set strdate to the finish date for the print
-                strtime = " " + format_date(finish_time, "EEE d")
+                strtime = " " + format_datetime(finish_time, format = "EEE d", locale = self._settings.get(['locale']))
         self.logger.debug('reached end of calculate_eta')
 
         # Join strtime and strdate and store it as eta_string
@@ -272,10 +281,10 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
             # Check if the user has chosen to remove colons from the output to the printer LCD
             if self.replaceColons is True:
                 # Send the ETA to the printer LCD, minus the colons
-                self._printer.commands("M117 ETA is {}".format(self.eta_string.replace(":", " ")))
+                self._printer.commands("M117 {}".format(self.eta_string.replace(":", " ")))
             else:
                 # Send the ETA to the printer LCD
-                self._printer.commands("M117 ETA is {}".format(self.eta_string))
+                self._printer.commands("M117 {}".format(self.eta_string))
         return
 
     # Function to tell Octoprint how to update the plugin

--- a/octoprint_display_eta/templates/display_eta_settings.jinja2
+++ b/octoprint_display_eta/templates/display_eta_settings.jinja2
@@ -1,15 +1,29 @@
-<form class="form-horizontal">
+<h3>{{ _('OctoPrint Display ETA') }} <small>{{ _('Version') }}: <span data-bind="text: settings.plugins.display_eta.installed_version"/></small></h3>
+    <legend>Time Format</legend>
     <div class="control-group">
         <div class="controls">
             <label class="checkbox">
-            <input type="checkbox" data-bind="checked: settings.plugins.display_eta.time24hr">{{ _('Use 24HR time instead of 12HR') }}
+            <input type="checkbox" data-bind="disable: settings.plugins.display_eta.customTimeStringEnable, checked: settings.plugins.display_eta.time24hr">{{ _('Use 24HR time instead of 12HR') }}
             </label>
+            <label class="checkbox">
+            <input type="checkbox" data-bind="disable: settings.plugins.display_eta.time24hr, checked: settings.plugins.display_eta.customTimeStringEnable">{{ _('Use a custom Babel time string') }}
+            </label>
+            <label>
+            <div data-bind="visible: settings.plugins.display_eta.customTimeStringEnable">
+            <label for="cts_input">Custom time string</label>
+                <input type="text" name="cts_input" data-bind="value: settings.plugins.display_eta.customTimeString">
+            </div>
+            </label>
+        </div>
+    </div>
+    <legend>Printer Settings</legend>
+    <div class="control-group">
+        <div class="controls">
 			<label class="checkbox">
-            <input type="checkbox" data-bind="checked: settings.plugins.display_eta.displayOnPrinter">{{ _('Display the ETA on your printers LCD screen') }}
+            <input type="checkbox" data-bind="checked: settings.plugins.display_eta.displayOnPrinter">{{ _('Display the ETA on your printer\'s LCD screen') }}
             </label>
 			<label class="checkbox">
             <input type="checkbox" data-bind="checked: settings.plugins.display_eta.removeColons">{{ _('Remove all colons(:) from the time that is displayed on the printer (required for certain printer firmwares)') }}
             </label>
         </div>
     </div>
-</form>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_display_eta"
 plugin_name = "OctoPrint Display ETA"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "2.1.0"
+plugin_version = "2.2.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* Allow use of custom time string

* Add time string settings and reorganize

* Move "ETA is" to time string

* Fix various issues

Signed-off-by: Layne Bernardo <LMBernar@uark.edu>

* Cleanup imports

Signed-off-by: Layne Bernardo <LMBernar@uark.edu>

Co-authored-by: Layne Bernardo <LMBernar@uark.edu>