### PR TITLE
Fixed variable missing in settings template

### DIFF
--- a/octoprint_display_eta/__init__.py
+++ b/octoprint_display_eta/__init__.py
@@ -123,6 +123,12 @@ class DisplayETAPlugin(octoprint.plugin.AssetPlugin,
             dict(type="settings", custom_bindings=False)
         ]
 
+    # Function to pass the 'version' variable to template
+    def get_template_vars(self):
+        return dict(
+            version=self._plugin_version
+        )
+
     ########################
     # ProgressPlugin Mixin #
     ########################

--- a/octoprint_display_eta/templates/display_eta_settings.jinja2
+++ b/octoprint_display_eta/templates/display_eta_settings.jinja2
@@ -1,4 +1,4 @@
-<h3>{{ _('OctoPrint Display ETA') }} <small>{{ _('Version') }}: <span data-bind="text: settings.plugins.display_eta.installed_version"/></small></h3>
+<h3>{{ _('OctoPrint Display ETA') }} <small>{{ _('Version') }}: {{ plugin_display_eta_version }}</small></h3>
     <legend>Time Format</legend>
     <div class="control-group">
         <div class="controls">


### PR DESCRIPTION
Settings menu shows empty version because of missing variable from defaults.